### PR TITLE
Fix typos in comments

### DIFF
--- a/building_score.m
+++ b/building_score.m
@@ -6,7 +6,7 @@ usage=unique(Build_Data(:,3));
 
 %% number of HH in building - smart calculation
 X=unique(Assets(Assets(:,11)==1,2)); % unique building id for occupied assets 
-Y=Assets(Assets(:,11)==1,2); % all accupied assets
+Y=Assets(Assets(:,11)==1,2); % all occupied assets
 H=histc(Y,(X)); % histogram for assets per building
 
 [~,locb]=ismember(X,Build_Data(:,1));

--- a/run_model.m
+++ b/run_model.m
@@ -141,7 +141,7 @@ for g=1:length(g_sa)
     SA_PRICE(g,1)=nanmean(Assets(Assets(:,1)==g_sa(g),5)); % mean assets price in SA
     SA_HOUSE(g,1)=nanmean(Assets(ismember(Assets(:, 2),Build_Data(Build_Data(:,3)==1 | Build_Data(:,3)==2,1)) & Assets(:,1)==g_sa(g), 5));
     SA_COMERCIAL(g,1)=nanmean(Assets(ismember(Assets(:, 2),Build_Data(Build_Data(:,3)>2,1)) & Assets(:,1)==g_sa(g), 5));
-    SA_POP(g,1)=sum(Assets(Assets(:,1)==g_sa(g),11)); % sum accupied assests in SA
+    SA_POP(g,1)=sum(Assets(Assets(:,1)==g_sa(g),11)); % sum occupied assets in SA
     SA_ASSETS(g,1)=sum(Assets(:,1)==g_sa(g)); % sum total assets in SA
     SA_SERVICE(g,1)=sum(Build_Data(Build_Data(:,4)==g_sa(g),3)>2); % sum all building with usage greater then 2
     SA_RESIDENT(g,1)=sum(Build_Data(Build_Data(:,4)==g_sa(g),3)==1 | Build_Data(Build_Data(:,4)==g_sa(g),3)==2); % sum all building with usage 1 or 2
@@ -720,7 +720,7 @@ for i = 1:steps
         SA_PRICE(g,i+1)=nanmean(Assets(Assets(:,1)==g_sa(g),5)); % mean 'price M' 
         SA_HOUSE(g,i+1)=nanmean(Assets(ismember(Assets(:, 2),Build_Data(Build_Data(:,3)==1 | Build_Data(:,3)==2,1)) & Assets(:,1)==g_sa(g), 5));
         SA_COMERCIAL(g,i+1)=nanmean(Assets(ismember(Assets(:, 2),Build_Data(Build_Data(:,3)>2,1)) & Assets(:,1)==g_sa(g), 5));
-        SA_POP(g,i+1)=sum(Assets(Assets(:,1)==g_sa(g),11)); % sum accupied assests in SA 
+        SA_POP(g,i+1)=sum(Assets(Assets(:,1)==g_sa(g),11)); % sum occupied assets in SA 
         SA_ASSETS(g,i+1)=sum(Assets(:,1)==g_sa(g)); % sum total assets in SA
         SA_SERVICE(g,i+1)=sum(Build_Data(Build_Data(:,4)==g_sa(g),3)>2); % sum all building with usage>2 
         SA_RESIDENT(g,i+1)=sum(Build_Data(Build_Data(:,4)==g_sa(g),3)==1 | Build_Data(Build_Data(:,4)==g_sa(g),3)==2); % sum all residential         


### PR DESCRIPTION
## Summary
- fix typo `accupied` → `occupied` in `building_score.m`
- correct `accupied assests` → `occupied assets` in `run_model.m`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842f1262374832996d7a78da3a66453